### PR TITLE
Optimize frame extraction by using keyframes for efficient decoding

### DIFF
--- a/tinyllava/eval/eval_mlvu.py
+++ b/tinyllava/eval/eval_mlvu.py
@@ -13,6 +13,7 @@ from tinyllava.model import *
 
 import av
 import random
+import bisect
 
 def get_prompt2(conv):
     ret = conv.system + conv.sep
@@ -181,7 +182,7 @@ data_list = {
         "topic_reasoning": ("7_topic_reasoning.json", f"/7_topic_reasoning", "video")
     }
 
-def get_video_frames(video_path, num_frames=16, max_frames=16):
+def get_video_frames_naive(video_path, num_frames=16, max_frames=16):
     container = av.open(video_path)
     total_frames = container.streams.video[0].frames
     duration = container.streams.video[0].duration
@@ -198,6 +199,73 @@ def get_video_frames(video_path, num_frames=16, max_frames=16):
         if len(frames) >= num_frames_to_extract:
             break
     return frames
+
+
+def get_video_frames(video_path, num_frames=16, max_frames=16):
+    # Open the video container
+    container = av.open(video_path)
+    video_stream = container.streams.video[0]
+
+    # Get the metadata of the video
+    if video_stream.average_rate == video_stream.base_rate:
+        frame_rate = float(video_stream.base_rate)
+    else:
+        # Variable frame rate mode -- hard to calculate PTSs
+        # Fallback to naive method
+        return get_video_frames_naive(video_path, num_frames, max_frames)
+    time_base = video_stream.time_base
+    total_frames = video_stream.frames
+
+    # Calculate the number of frames to extract
+    if num_frames > 0:
+        num_frames_to_extract = num_frames
+    else:
+        duration = video_stream.duration * time_base
+        num_frames_to_extract = min(max_frames, max(1, int(duration)))
+
+    frame_indices = np.linspace(0, total_frames - 1, num_frames_to_extract, dtype=int)
+    frame_indices = np.unique(frame_indices)
+
+    # Calculate timestamps (PTS) of target frames, ensuring reverse order and no duplicates
+    remaining_PTSs = (frame_indices / time_base / frame_rate).astype(int).tolist()
+
+    frame_dict = {}
+
+    while remaining_PTSs:
+        # Jump to the nearest keyframe (I-frame) before the target frame
+        container.seek(
+            remaining_PTSs[-1],
+            stream=video_stream,
+            backward=True,
+            any_frame=False
+        )
+        init = True
+
+        # Decode and find the target frame,
+        # considering the case where the keyframe is followed by multiple target frames
+        for frame in container.decode(video=0):
+            frame_PTS = frame.pts
+            if init:
+                index = bisect.bisect_left(remaining_PTSs, frame_PTS)
+                this_PTSs = remaining_PTSs[index:]
+                if not this_PTSs:
+                    # In some cases (maybe some variable frame rate videos),
+                    # the first keyframe is not indexed as frame 0.
+                    index = 0
+                    this_PTSs = remaining_PTSs[index:]
+                remaining_PTSs = remaining_PTSs[:index]
+                init = False
+
+            if frame_PTS >= this_PTSs[0]:
+                frame_dict[frame_PTS] = frame.to_image()
+                this_PTSs.pop(0)
+
+                if not this_PTSs:
+                    break
+
+    sorted_PTS = sorted(frame_dict.keys())
+    return [frame_dict[pts] for pts in sorted_PTS]
+
 
 def eval_model(args):
 
@@ -218,6 +286,7 @@ def eval_model(args):
     acc_dict = {}
     for example in tqdm(dataset):
         task_type = example['task_type']
+        print(f"Video: {example['video']}")
         if task_type not in acc_dict:
             acc_dict[task_type] = [0, 0] # correct, total
         acc_dict[task_type][1] += 1


### PR DESCRIPTION
resolves #3

## Description:

This update optimizes the `get_video_frames` method by seeking keyframes (I-Frames) to start decoding and avoiding decoding the entire video, significantly improving frame extraction performance and reducing evaluation time, especially for large videos. 

## Key Changes

- Implemented keyframe-based frame extraction for more efficient decoding.
- For videos with variable frame rates (VFR), the method falls back to the original approach (`get_video_frames_naive`).
- Frame extraction results are consistent with the original method, ensuring no loss in functionality.

[algorithm.webm](https://github.com/user-attachments/assets/aa811183-000d-4b9d-ae5e-1a4c6d18883c)

## Performance

On the MLVU task, frame extraction time decreased from 30 hours to less than 4 hours, a nearly **10x speedup**.

## Known Issues

- The method might fail for some videos with variable frame rates (VFR).
- Tested and confirmed on MLVU; further testing on other tasks will follow.

## Next Steps

Please report any issues encountered, and I’ll address them promptly.
